### PR TITLE
Y役職移植：キャンドルライター

### DIFF
--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -133,6 +133,7 @@
 "Walker","walker","ウォーカー"
 "AllArounder","AllArounder","オールラウンダー"
 "Inspector","Inspector","捜査官"
+"CandleLighter","Candle Lighter","キャンドルライター",
 "#CrewmateName"
 
 "# ニュートラル役職"
@@ -402,6 +403,7 @@
 "WalkerInfo","Walk a lot!","てくてく"
 "AllArounderInfo","I can do anything!","僕、なんでもできます！"
 "InspectorInfo","","全てわかりました...犯人は..."
+"CandleLighterInfo","By the time the wax is gone...","ろうが無くなるまでには、、",
 "#CrewmateInfo"
 
 "# ニュートラル役職"
@@ -632,6 +634,7 @@
 "WalkerInfoLong","","通常のタスクの他に、特定の部屋に行くというタスクが追加される。\n特定の部屋に行くタスクも通常のタスクも、クルーメイト勝利のカウントに含まれる。"
 "AllArounderInfoLong","","ターン毎に設定された確率に応じて、様々な役職や能力に変化する。\n\nマッドメイト、オポチュニストの場合、そのターンの間タスクは勝利カウントに計算されない。\n\n基本通信妨害中は能力が使用できない"
 "InspectorInfoLong","","会議で自投票すると捜査モードに変更できる。\n捜査モードの状態で誰かに投票するとその人の事を次のターンの間、捜査することができる。\n\n捜査相手が死亡すると、捜査相手や捜査相手を殺した犯人についての情報を手に入れることができる。\n\n会議が始まると捜査はリセットされる。\nまた、複数人同時捜査はできない。"
+"CandleLighterInfoLong","","視界がろうそくのようにだんだんと小さく狭くなっていく。ただ、他人と違いろうそくで周りを灯している為、停電の影響は受けない。\nタスクを全て完了させると新たに一本ろうそくが供給され、一番明るい状態に点け直すことができる。",
 "#CrewmateInfoLong"
 
 "# ニュートラル役職"
@@ -1421,6 +1424,10 @@
 "AllArounderRandomOpportunist","Opportunist rate","<#00ff00>オポチュニスト</color>になる確率"
 "AllArounderRandomNone","Crewmate rate","<#8cffff>クルーメイト</color>になる確率"
 "InspectVoteMode","VoteMode","捜査方法"
+"CandleLighterStartVision","Start Vision(Widest Vision)","初めの視界(一番広い視界)",
+"CandleLighterCountStartTime","Time to Start Changing Vision","視界が変わり始めるまでの時間",
+"CandleLighterEndVisionTime","Time to End Vision","最後の視界になる時間",
+"CandleLighterEndVision","End Vision(Narrowest Vision)","最後の視界(一番狭い視界)",
 
 "## Neutral Role Setting"
 "SchrodingerCatExiledTeamChanges","Team Changes When Ejected","吊られた際、陣営が変化する","薛定谔的猫被放逐时会加入其他阵营","薛定諤的貓被丟出時陣營會轉變","Команда меняется после его Изгнания","Time Muda Quando Exilado",""

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -827,6 +827,7 @@ public enum CustomRoles
     VentOpener,
     VentHunter,
     Walker,
+    CandleLighter,
     //DEBUG only Crewmate
     Inspector,
     AllArounder,

--- a/Roles/Crewmate/CandleLighter.cs
+++ b/Roles/Crewmate/CandleLighter.cs
@@ -1,0 +1,132 @@
+using AmongUs.GameOptions;
+using TownOfHost;
+using TownOfHost.Roles.Core;
+using TownOfHost.Roles.Crewmate;
+using UnityEngine;
+
+namespace TownOfHost.Roles.Crewmate;
+public sealed class CandleLighter : RoleBase
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+         SimpleRoleInfo.Create(
+            typeof(Lighter),
+            player => new CandleLighter(player),
+            CustomRoles.CandleLighter,
+            () => RoleTypes.Crewmate,
+            CustomRoleTypes.Crewmate,
+            25100,
+            SetupOptionItem,
+            "cl",
+            "#ff7f50",
+            from: From.TownOfHost_Y
+        );
+
+    public CandleLighter(PlayerControl player)
+    : base(
+        RoleInfo,
+        player
+    )
+    {
+        startVision = OptionTaskStartVision.GetFloat();
+        endVision = OptionTaskEndVision.GetFloat();
+        countStartTime = OptionCountStartTime.GetInt();
+        endVisionTime = OptionTaskEndVisionTime.GetInt();
+    }
+
+    private static OptionItem OptionTaskStartVision;
+    private static OptionItem OptionCountStartTime;
+    private static OptionItem OptionTaskEndVisionTime;
+    private static OptionItem OptionTaskEndVision;
+
+    enum OptionName
+    {
+        CandleLighterStartVision,
+        CandleLighterCountStartTime,
+        CandleLighterEndVisionTime,
+        CandleLighterEndVision,
+        CandleLighterTimeMoveMeeting,
+    }
+
+    private static float startVision;
+    private static float endVision;
+    private static int endVisionTime;
+    private static int countStartTime;
+
+    private float visionTimer;
+    private int lastProcessedSecond;
+
+    private static void SetupOptionItem()
+    {
+        OptionTaskStartVision = FloatOptionItem.Create(RoleInfo, 10, OptionName.CandleLighterStartVision, new(0.5f, 5f, 0.1f), 2.0f, false)
+            .SetValueFormat(OptionFormat.Multiplier);
+        OptionCountStartTime = IntegerOptionItem.Create(RoleInfo, 11, OptionName.CandleLighterCountStartTime, new(0, 300, 10), 0, false)
+            .SetValueFormat(OptionFormat.Seconds);
+        OptionTaskEndVisionTime = IntegerOptionItem.Create(RoleInfo, 12, OptionName.CandleLighterEndVisionTime, new(60, 1200, 60), 480, false)
+            .SetValueFormat(OptionFormat.Seconds);
+        OptionTaskEndVision = FloatOptionItem.Create(RoleInfo, 13, OptionName.CandleLighterEndVision, new(0f, 0.5f, 0.05f), 0.1f, false)
+            .SetValueFormat(OptionFormat.Multiplier);
+    }
+
+    public override void Add()
+    {
+        lastProcessedSecond = -1;
+        visionTimer = endVisionTime + countStartTime;
+    }
+
+    public override void ApplyGameOptions(IGameOptions opt)
+    {
+        float Vision = 0f;
+
+        // 初めの変化待機時間中は最大視界
+        if (visionTimer > endVisionTime)
+        {
+            Vision = startVision;
+        }
+        else
+        {
+            Vision = startVision * (visionTimer / endVisionTime);
+        }
+
+        // 視界が設定最小視界より小さくなった時は強制
+        if (Vision <= endVision)
+        {
+            Vision = endVision;
+        }
+
+        // 停電は無効
+        if (Utils.IsActive(SystemTypes.Electrical))
+        {
+            opt.SetFloat(FloatOptionNames.CrewLightMod, Vision * 5);
+        }
+        else
+        {
+            opt.SetFloat(FloatOptionNames.CrewLightMod, Vision);
+        }
+    }
+
+    public override bool OnCompleteTask(uint taskid)
+    {
+        if (Player.IsAlive() && IsTaskFinished)
+        {
+            // タスク完了で視界を一番広く(更新時間をリセット)する
+            visionTimer = endVisionTime;
+        }
+
+        return true;
+    }
+
+    public override void OnFixedUpdate(PlayerControl player)
+    {
+        if (visionTimer > 0f)
+        {
+            visionTimer -= Time.fixedDeltaTime;
+            int currentSecond = Mathf.FloorToInt(visionTimer);
+
+            if (currentSecond != lastProcessedSecond)
+            {
+                lastProcessedSecond = currentSecond;
+                player.SyncSettings();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 役職
- キャンドルライター

  - 陣営：クルー
  - 判定：クルーメイト

## 説明
- 視界がろうそくのようにだんだんと小さく狭くなっていく。しかし他人と違いろうそくで周りを灯している為、停電の影響は受けない。
- タスクを全て完了させると新たに一本ろうそくが供給され、一番明るい状態に点け直すことができる。

## 設定
設定名 | (設定値 / デフォルト値) | 説明
-- | -- | --
初めの視界(一番広い視界) | 0.5 / 5 / 0.1 (x2.0) | 
視界が変わり始めるまでの時間 | 0 / 300 / 10 (0s) | 
最後の視界になる時間 | 60 / 1200 / 60 (480s) | 
最後の視界(一番狭い視界) | 0 / 0.5 / 0.05f (x0.1) | 

## 補足
- 会議中、ろうそく消費に関する時間経過はありません。